### PR TITLE
Fix metamemory processing trigger

### DIFF
--- a/src/metamemory/index.ts
+++ b/src/metamemory/index.ts
@@ -46,6 +46,7 @@ export class Metamemory {
       },
       slidingWindowSize: 20,
       compactionInterval: 300000, // 5 minutes
+      processingThreshold: 5,
       ...options.config
     };
     
@@ -67,7 +68,8 @@ export class Metamemory {
    */
   async processMessages(messages: ResponseInput): Promise<void> {
     // Add new messages to the queue
-    this.messageQueue.push(...messages.slice(this.lastProcessedIndex));
+    const newMessages = messages.slice(this.lastProcessedIndex);
+    this.messageQueue.push(...newMessages);
     this.lastProcessedIndex = messages.length;
     
     // Don't process if already processing
@@ -75,8 +77,9 @@ export class Metamemory {
       return;
     }
     
-    // Process if we have enough messages or if force processing
-    if (this.messageQueue.length < 5 && this.messageQueue.length < messages.length) {
+    // Determine if processing should run
+    const threshold = this.config.processingThreshold;
+    if (newMessages.length === 0 && this.messageQueue.length < threshold) {
       return;
     }
     

--- a/src/metamemory/types/index.ts
+++ b/src/metamemory/types/index.ts
@@ -40,6 +40,10 @@ export interface MetaMemoryConfig {
   };
   slidingWindowSize: number;
   compactionInterval: number;
+  /**
+   * Minimum number of queued messages before automatic processing
+   */
+  processingThreshold: number;
 }
 
 export interface CompactionLevel {

--- a/test/metamemory-new.test.ts
+++ b/test/metamemory-new.test.ts
@@ -312,4 +312,29 @@ describe('MetaMemory System', () => {
       expect(newState.threads.size).toBe(1);
     });
   });
+
+  describe('Processing thresholds', () => {
+    it('processes small conversations', async () => {
+      const metamemory = new Metamemory({
+        agent: mockAgent,
+        taggerLLM: new MockTaggerLLM(),
+        summarizer: new MockSummarizer(),
+        config: { processingThreshold: 5, compactionInterval: 0 }
+      });
+
+      const mmAny = metamemory as any;
+      const tagSpy = vi.spyOn(mmAny.tagger, 'tagMessages');
+      const compSpy = vi.spyOn(mmAny.compactor, 'runCompactionCycle').mockResolvedValue();
+
+      const messages: ResponseInput = [
+        { id: 'm1', role: 'user', content: 'Hello' },
+        { id: 'm2', role: 'assistant', content: 'Hi' }
+      ];
+
+      await metamemory.processMessages(messages);
+
+      expect(tagSpy).toHaveBeenCalled();
+      expect(compSpy).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add `processingThreshold` to MetaMemoryConfig
- process messages immediately if new messages arrive
- test small conversations trigger tagging and compaction

## Testing
- `npm run build`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_6869ae50557c832ab6bbc35188e5bf7b