### PR TITLE
Add vector search persistence

### DIFF
--- a/src/metamemory/types/index.ts
+++ b/src/metamemory/types/index.ts
@@ -1,7 +1,18 @@
 export type TopicState = 'core' | 'active' | 'idle' | 'archived' | 'ephemeral';
 
 // Add the missing type for backwards compatibility
-export type { MetamemoryState } from '../../metamemory-old/types.js';
+import type { MetamemoryState as LegacyMetamemoryState } from '../../metamemory-old/types.js';
+
+export interface VectorEmbeddings {
+  [topicName: string]: {
+    summary: string;
+    embedding: number[];
+  };
+}
+
+export interface MetamemoryState extends LegacyMetamemoryState {
+  vectorEmbeddings?: VectorEmbeddings;
+}
 
 export interface Message {
   id: string;

--- a/src/metamemory/utils/vector-search.ts
+++ b/src/metamemory/utils/vector-search.ts
@@ -104,12 +104,37 @@ export class InMemoryVectorSearch implements VectorSearchInterface {
   clear(): void {
     this.embeddings.clear();
   }
-  
+
   /**
    * Get the number of indexed threads
    */
   size(): number {
     return this.embeddings.size;
+  }
+
+  /**
+   * Export embeddings for persistence
+   */
+  exportEmbeddings(): Record<string, { summary: string; embedding: number[] }> {
+    const data: Record<string, { summary: string; embedding: number[] }> = {};
+    for (const [topicName, value] of this.embeddings) {
+      data[topicName] = { summary: value.summary, embedding: value.embedding };
+    }
+    return data;
+  }
+
+  /**
+   * Load embeddings from persisted state
+   */
+  loadEmbeddings(data: Record<string, { summary: string; embedding: number[] }>): void {
+    this.embeddings.clear();
+    for (const [topicName, value] of Object.entries(data)) {
+      this.embeddings.set(topicName, {
+        topicName,
+        summary: value.summary,
+        embedding: value.embedding,
+      });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- extend vector search and metamemory types to serialize embeddings
- persist embeddings in `Metamemory.getState` and reload in `restoreState`
- expose vector search instance on `Metamemory`
- test vector embeddings survive archive/restore cycle

## Testing
- `npm run lint`
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_6869ae29115c832a8927ab40853eb7b6