### PR TITLE
Add metamemory history compaction

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -548,15 +548,17 @@ export function addMessageToTask(
  * ```
  */
 export async function getCompactedHistory(
-    state: TaskEvent['finalState']
-): Promise<any> {
+    state: TaskEvent['finalState'],
+    agent: Agent
+): Promise<ResponseInput | null> {
     if (!state.metamemoryEnabled || !state.metamemoryState) {
         return null;
     }
-    
-    // Need to pass an agent for the new metamemory implementation
-    // This is a limitation of the current design - we need an agent to compact history
-    throw new Error('getCompactedHistory is not supported with the new metamemory implementation. Use metamemory through runTask instead.');
+
+    const metamemory = new Metamemory({ agent });
+    metamemory.restoreState(state.metamemoryState);
+
+    return metamemory.compactHistory(state.messages);
 }
 
 /**

--- a/src/metamemory/index.ts
+++ b/src/metamemory/index.ts
@@ -249,6 +249,27 @@ export class Metamemory {
   async forceCompaction(): Promise<void> {
     await this.compactor.runCompactionCycle();
   }
+
+  /**
+   * Build a compacted history using current threads and vector search.
+   * This runs a compaction cycle to update summaries before assembling context.
+   */
+  async compactHistory(
+    recentMessages: ResponseInput,
+    options?: Partial<ContextAssemblyOptions>
+  ): Promise<ResponseInput> {
+    await this.compactor.runCompactionCycle();
+
+    const assemblyOptions: ContextAssemblyOptions = {
+      maxTokens: 100000,
+      includeIdleSummaries: true,
+      includeArchivedSearch: true,
+      recentMessageCount: 30,
+      ...options
+    };
+
+    return this.contextAssembler.buildContext(recentMessages, assemblyOptions);
+  }
   
   /**
    * Get memory statistics

--- a/test/metamemory-new.test.ts
+++ b/test/metamemory-new.test.ts
@@ -312,4 +312,32 @@ describe('MetaMemory System', () => {
       expect(newState.threads.size).toBe(1);
     });
   });
+
+  describe('History Compaction', () => {
+    it('should compact history to fewer messages', async () => {
+      const metamemory = new Metamemory({
+        agent: mockAgent,
+        taggerLLM: new MockTaggerLLM(),
+        summarizer: new MockSummarizer()
+      });
+
+      const messages: ResponseInput = [];
+      for (let i = 0; i < 50; i++) {
+        messages.push({
+          id: `msg_${i}`,
+          role: i % 2 === 0 ? 'user' : 'assistant',
+          content: `Message number ${i}`
+        });
+      }
+
+      await metamemory.processMessages(messages);
+
+      const compacted = await metamemory.compactHistory(messages, {
+        maxTokens: 40,
+        recentMessageCount: 5
+      });
+
+      expect(compacted.length).toBeLessThan(messages.length);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- implement `compactHistory` in metamemory module for summarised history building
- call the new method from `getCompactedHistory`
- add unit test verifying history compaction

## Testing
- `npm test`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6869ae78cd68832aa0ba65bfdcf818d3